### PR TITLE
feat: Add `CheckEmailInput` setter `set_` prefix to differentiate with accessing fields

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,13 +2,11 @@
 
 name: CI
 
- on:
-   push:
-     branches:
-       - master
-   pull_request:
-     branches:
-       - master
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   check:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,13 @@
 
 name: CI
 
-on: [pull_request]
+ on:
+   push:
+     branches:
+       - master
+   pull_request:
+     branches:
+       - master
 
 jobs:
   check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.8.23](https://github.com/amaurymartiny/check-if-email-exists/compare/v0.8.22...v0.8.23) (2021-06-20)
+
+
+### Bug Fixes
+
+* Add serde (De)Serialize to pub structs ([#931](https://github.com/amaurymartiny/check-if-email-exists/issues/931)) ([949475d](https://github.com/amaurymartiny/check-if-email-exists/commit/949475dee4a1ed96e873688e7432c702eb30af62))
+
 ### [0.8.22](https://github.com/amaurymartiny/check-if-email-exists/compare/v0.8.21...v0.8.22) (2021-03-31)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Deprecated.
 # This Dockerfile is for demo purposes, and should not be used in production.
 # For a production-ready web server, please see https://github.com/reacherhq/backend.
-# This Dockerfile will be **deprecated** soon: https://hub.docker.com/r/reacherhq/check-if-email-exists.
+# This Dockerfile will be **deprecated** soon, and removed from the
+# Docker Hub: https://hub.docker.com/r/reacherhq/check-if-email-exists.
 FROM alpine
 
 # `ciee` stands for check-if-email-exists

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# Deprecated.
+# This Dockerfile is for demo purposes, and should not be used in production.
+# For a production-ready web server, please see https://github.com/reacherhq/backend.
+# This Dockerfile will be **deprecated** soon: https://hub.docker.com/r/reacherhq/check-if-email-exists.
 FROM alpine
 
 # `ciee` stands for check-if-email-exists

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ async fn check() {
     input
         .set_from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
         .set_hello_name("example.org".into())    // Used in the `EHLO` command
-		.set_proxy(CheckEmailInputProxy{         // Use a SOCKS5 proxy to verify the email
+		.set_proxy(CheckEmailInputProxy {         // Use a SOCKS5 proxy to verify the email
 			host: "my-proxy.io".into(),
 			port: 1080
 		});

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ async fn check() {
     input
         .set_from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
         .set_hello_name("example.org".into())    // Used in the `EHLO` command
-		.set_proxy(CheckEmailInputProxy {         // Use a SOCKS5 proxy to verify the email
-			host: "my-proxy.io".into(),
-			port: 1080
-		});
+        .set_proxy(CheckEmailInputProxy {         // Use a SOCKS5 proxy to verify the email
+            host: "my-proxy.io".into(),
+            port: 1080
+        });
 
     // Verify this email, using async/await syntax.
     let result = check_email(&input).await;

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ async fn check() {
     // Optionally, we can also tweak the configuration parameters used in the
     // verification.
     input
-        .with_from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
-        .with_hello_name("example.org".into())    // Used in the `EHLO` command
-		.with_proxy(CheckEmailInputProxy{         // Use a SOCKS5 proxy to verify the email
+        .set_from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
+        .set_hello_name("example.org".into())    // Used in the `EHLO` command
+		.set_proxy(CheckEmailInputProxy{         // Use a SOCKS5 proxy to verify the email
 			host: "my-proxy.io".into(),
 			port: 1080
 		});

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ check-if-email-exists = "0.8"
 And use it in your code as follows:
 
 ```rust
-use check_if_email_exists::{check_email, CheckEmailInput};
+use check_if_email_exists::{check_email, CheckEmailInput, CheckEmailInputProxy};
 
 async fn check() {
     // Let's say we want to test the deliverability of someone@gmail.com.
@@ -182,10 +182,14 @@ async fn check() {
     // Optionally, we can also tweak the configuration parameters used in the
     // verification.
     input
-        .from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
-        .hello_name("example.org".into()); // Used in the `EHLO` command
+        .with_from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
+        .with_hello_name("example.org".into())    // Used in the `EHLO` command
+		.with_proxy(CheckEmailInputProxy{         // Use a SOCKS5 proxy to verify the email
+			host: "my-proxy.io".into(),
+			port: 1080
+		});
 
-    // Verify this input, using async/await syntax.
+    // Verify this email, using async/await syntax.
     let result = check_email(&input).await;
 
     // `result` is a `Vec<CheckEmailOutput>`, where the CheckEmailOutput

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,8 +43,12 @@
 //!     // Optionally, we can also tweak the configuration parameters used in the
 //!     // verification.
 //!     input
-//!         .from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
-//!         .hello_name("example.org".into()); // Used in the `EHLO` command
+//!         .set_from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
+//!         .set_hello_name("example.org".into())    // Used in the `EHLO` command
+//!         .set_proxy(CheckEmailInputProxy{         // Use a SOCKS5 proxy to verify the email
+//!             host: "my-proxy.io".into(),
+//!             port: 1080
+//!     });
 //!
 //!     // Verify this input, using async/await syntax.
 //!     let result = check_email(&input).await;
@@ -191,6 +195,11 @@ async fn check_single_email(input: CheckEmailInput) -> CheckEmailOutput {
 /// The main function of this library: takes as input a list of email addresses
 /// to check. Then performs syntax, mx, smtp and misc checks, and outputs a
 /// list of results.
+///
+/// Please note that checking multiple emails at once (by putting multiple
+/// emails in the `inputs.to_emails` Vec) is still a beta feature, and not
+/// fully optimized. For more info, see #65
+/// <https://github.com/reacherhq/check-if-email-exists/issues/65>.
 pub async fn check_email(inputs: &CheckEmailInput) -> Vec<CheckEmailOutput> {
 	// FIXME Obviously, the below `join_all` is not optimal. Some optimizations
 	// include:

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,7 @@
 //! - Catch-all address. Is this email address a catch-all address?
 //!
 //! ```rust
-//! use check_if_email_exists::{check_email, CheckEmailInput};
+//! use check_if_email_exists::{check_email, CheckEmailInput, CheckEmailInputProxy};
 //!
 //! async fn check() {
 //!     // Let's say we want to test the deliverability of someone@gmail.com.
@@ -45,7 +45,7 @@
 //!     input
 //!         .set_from_email("me@example.org".into()) // Used in the `MAIL FROM:` command
 //!         .set_hello_name("example.org".into())    // Used in the `EHLO` command
-//!         .set_proxy(CheckEmailInputProxy{         // Use a SOCKS5 proxy to verify the email
+//!         .set_proxy(CheckEmailInputProxy {         // Use a SOCKS5 proxy to verify the email
 //!             host: "my-proxy.io".into(),
 //!             port: 1080
 //!     });

--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -448,7 +448,7 @@ mod tests {
 		let to_email = EmailAddress::from_str("foo@gmail.com").unwrap();
 		let host = Name::from_str("gmail.com").unwrap();
 		let mut input = CheckEmailInput::default();
-		input.with_smtp_timeout(Duration::from_millis(1));
+		input.set_smtp_timeout(Duration::from_millis(1));
 
 		let res = runtime.block_on(check_smtp(&to_email, &host, 25, "gmail.com", &input));
 		match res {

--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -448,7 +448,7 @@ mod tests {
 		let to_email = EmailAddress::from_str("foo@gmail.com").unwrap();
 		let host = Name::from_str("gmail.com").unwrap();
 		let mut input = CheckEmailInput::default();
-		input.smtp_timeout(Duration::from_millis(1));
+		input.with_smtp_timeout(Duration::from_millis(1));
 
 		let res = runtime.block_on(check_smtp(&to_email, &host, 25, "gmail.com", &input));
 		match res {

--- a/core/src/util/input_output.rs
+++ b/core/src/util/input_output.rs
@@ -45,7 +45,7 @@ pub struct CheckEmailInput {
 	///
 	/// Defaults to "localhost" (note: "localhost" is not a FQDN).
 	pub hello_name: String,
-	/// Perform the email verification via a specified proxy. The usage of a
+	/// Perform the email verification via the specified SOCK5 proxy. The usage of a
 	/// proxy is optional.
 	pub proxy: Option<CheckEmailInputProxy>,
 	/// Add optional timeout for the SMTP verification step.
@@ -79,19 +79,38 @@ impl CheckEmailInput {
 		}
 	}
 
-	/// Set the email to use in the `MAIL FROM:` SMTP command.
+	/// Set the email to use in the `MAIL FROM:` SMTP command. Defaults to
+	/// `user@example.org` if not explicitly set.
+	#[deprecated(since = "0.8.24", note = "Please with with_from_email instead")]
 	pub fn from_email(&mut self, email: String) -> &mut CheckEmailInput {
 		self.from_email = email;
 		self
 	}
 
-	/// Set the name to use in the `EHLO:` SMTP command.
+	/// Set the email to use in the `MAIL FROM:` SMTP command. Defaults to
+	/// `user@example.org` if not explicitly set.
+	pub fn with_from_email(&mut self, email: String) -> &mut CheckEmailInput {
+		self.from_email = email;
+		self
+	}
+
+	/// Set the name to use in the `EHLO:` SMTP command. Defaults to `localhost`
+	/// if not explicitly set.
+	#[deprecated(since = "0.8.24", note = "Please with with_hello_name instead")]
 	pub fn hello_name(&mut self, name: String) -> &mut CheckEmailInput {
 		self.hello_name = name;
 		self
 	}
 
-	/// Use the specified proxy to perform email verification.
+	/// Set the name to use in the `EHLO:` SMTP command. Defaults to `localhost`
+	/// if not explicitly set.
+	pub fn with_hello_name(&mut self, name: String) -> &mut CheckEmailInput {
+		self.hello_name = name;
+		self
+	}
+
+	/// Use the specified SOCK5 proxy to perform email verification.
+	#[deprecated(since = "0.8.24", note = "Please with with_proxy instead")]
 	pub fn proxy(&mut self, proxy_host: String, proxy_port: u16) -> &mut CheckEmailInput {
 		self.proxy = Some(CheckEmailInputProxy {
 			host: proxy_host,
@@ -100,15 +119,36 @@ impl CheckEmailInput {
 		self
 	}
 
+	/// Use the specified SOCK5 proxy to perform email verification.
+	pub fn with_proxy(&mut self, proxy: CheckEmailInputProxy) -> &mut CheckEmailInput {
+		self.proxy = Some(proxy);
+		self
+	}
+
 	/// Add optional timeout for the SMTP verification step.
+	#[deprecated(since = "0.8.24", note = "Please with with_smtp_timeout instead")]
 	pub fn smtp_timeout(&mut self, duration: Duration) -> &mut CheckEmailInput {
 		self.smtp_timeout = Some(duration);
 		self
 	}
 
+	/// Add optional timeout for the SMTP verification step.
+	pub fn with_smtp_timeout(&mut self, duration: Duration) -> &mut CheckEmailInput {
+		self.smtp_timeout = Some(duration);
+		self
+	}
+
 	/// Set whether to use Yahoo's API or connecting directly to their SMTP
-	/// servers.
+	/// servers. Defaults to true.
+	#[deprecated(since = "0.8.24", note = "Please with with_yahoo_use_api instead")]
 	pub fn yahoo_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
+		self.yahoo_use_api = use_api;
+		self
+	}
+
+	/// Set whether to use Yahoo's API or connecting directly to their SMTP
+	/// servers. Defaults to true.
+	pub fn with_yahoo_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
 		self.yahoo_use_api = use_api;
 		self
 	}

--- a/core/src/util/input_output.rs
+++ b/core/src/util/input_output.rs
@@ -81,7 +81,7 @@ impl CheckEmailInput {
 
 	/// Set the email to use in the `MAIL FROM:` SMTP command. Defaults to
 	/// `user@example.org` if not explicitly set.
-	#[deprecated(since = "0.8.24", note = "Please with set_from_email instead")]
+	#[deprecated(since = "0.8.24", note = "Please use set_from_email instead")]
 	pub fn from_email(&mut self, email: String) -> &mut CheckEmailInput {
 		self.from_email = email;
 		self
@@ -96,7 +96,7 @@ impl CheckEmailInput {
 
 	/// Set the name to use in the `EHLO:` SMTP command. Defaults to `localhost`
 	/// if not explicitly set.
-	#[deprecated(since = "0.8.24", note = "Please with set_hello_name instead")]
+	#[deprecated(since = "0.8.24", note = "Please use set_hello_name instead")]
 	pub fn hello_name(&mut self, name: String) -> &mut CheckEmailInput {
 		self.hello_name = name;
 		self
@@ -110,7 +110,7 @@ impl CheckEmailInput {
 	}
 
 	/// Use the specified SOCK5 proxy to perform email verification.
-	#[deprecated(since = "0.8.24", note = "Please with set_proxy instead")]
+	#[deprecated(since = "0.8.24", note = "Please use set_proxy instead")]
 	pub fn proxy(&mut self, proxy_host: String, proxy_port: u16) -> &mut CheckEmailInput {
 		self.proxy = Some(CheckEmailInputProxy {
 			host: proxy_host,
@@ -126,7 +126,7 @@ impl CheckEmailInput {
 	}
 
 	/// Add optional timeout for the SMTP verification step.
-	#[deprecated(since = "0.8.24", note = "Please with set_smtp_timeout instead")]
+	#[deprecated(since = "0.8.24", note = "Please use set_smtp_timeout instead")]
 	pub fn smtp_timeout(&mut self, duration: Duration) -> &mut CheckEmailInput {
 		self.smtp_timeout = Some(duration);
 		self
@@ -140,7 +140,7 @@ impl CheckEmailInput {
 
 	/// Set whether to use Yahoo's API or connecting directly to their SMTP
 	/// servers. Defaults to true.
-	#[deprecated(since = "0.8.24", note = "Please with set_yahoo_use_api instead")]
+	#[deprecated(since = "0.8.24", note = "Please use set_yahoo_use_api instead")]
 	pub fn yahoo_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
 		self.yahoo_use_api = use_api;
 		self

--- a/core/src/util/input_output.rs
+++ b/core/src/util/input_output.rs
@@ -81,7 +81,7 @@ impl CheckEmailInput {
 
 	/// Set the email to use in the `MAIL FROM:` SMTP command. Defaults to
 	/// `user@example.org` if not explicitly set.
-	#[deprecated(since = "0.8.24", note = "Please with with_from_email instead")]
+	#[deprecated(since = "0.8.24", note = "Please with set_from_email instead")]
 	pub fn from_email(&mut self, email: String) -> &mut CheckEmailInput {
 		self.from_email = email;
 		self
@@ -89,14 +89,14 @@ impl CheckEmailInput {
 
 	/// Set the email to use in the `MAIL FROM:` SMTP command. Defaults to
 	/// `user@example.org` if not explicitly set.
-	pub fn with_from_email(&mut self, email: String) -> &mut CheckEmailInput {
+	pub fn set_from_email(&mut self, email: String) -> &mut CheckEmailInput {
 		self.from_email = email;
 		self
 	}
 
 	/// Set the name to use in the `EHLO:` SMTP command. Defaults to `localhost`
 	/// if not explicitly set.
-	#[deprecated(since = "0.8.24", note = "Please with with_hello_name instead")]
+	#[deprecated(since = "0.8.24", note = "Please with set_hello_name instead")]
 	pub fn hello_name(&mut self, name: String) -> &mut CheckEmailInput {
 		self.hello_name = name;
 		self
@@ -104,13 +104,13 @@ impl CheckEmailInput {
 
 	/// Set the name to use in the `EHLO:` SMTP command. Defaults to `localhost`
 	/// if not explicitly set.
-	pub fn with_hello_name(&mut self, name: String) -> &mut CheckEmailInput {
+	pub fn set_hello_name(&mut self, name: String) -> &mut CheckEmailInput {
 		self.hello_name = name;
 		self
 	}
 
 	/// Use the specified SOCK5 proxy to perform email verification.
-	#[deprecated(since = "0.8.24", note = "Please with with_proxy instead")]
+	#[deprecated(since = "0.8.24", note = "Please with set_proxy instead")]
 	pub fn proxy(&mut self, proxy_host: String, proxy_port: u16) -> &mut CheckEmailInput {
 		self.proxy = Some(CheckEmailInputProxy {
 			host: proxy_host,
@@ -120,27 +120,27 @@ impl CheckEmailInput {
 	}
 
 	/// Use the specified SOCK5 proxy to perform email verification.
-	pub fn with_proxy(&mut self, proxy: CheckEmailInputProxy) -> &mut CheckEmailInput {
+	pub fn set_proxy(&mut self, proxy: CheckEmailInputProxy) -> &mut CheckEmailInput {
 		self.proxy = Some(proxy);
 		self
 	}
 
 	/// Add optional timeout for the SMTP verification step.
-	#[deprecated(since = "0.8.24", note = "Please with with_smtp_timeout instead")]
+	#[deprecated(since = "0.8.24", note = "Please with set_smtp_timeout instead")]
 	pub fn smtp_timeout(&mut self, duration: Duration) -> &mut CheckEmailInput {
 		self.smtp_timeout = Some(duration);
 		self
 	}
 
 	/// Add optional timeout for the SMTP verification step.
-	pub fn with_smtp_timeout(&mut self, duration: Duration) -> &mut CheckEmailInput {
+	pub fn set_smtp_timeout(&mut self, duration: Duration) -> &mut CheckEmailInput {
 		self.smtp_timeout = Some(duration);
 		self
 	}
 
 	/// Set whether to use Yahoo's API or connecting directly to their SMTP
 	/// servers. Defaults to true.
-	#[deprecated(since = "0.8.24", note = "Please with with_yahoo_use_api instead")]
+	#[deprecated(since = "0.8.24", note = "Please with set_yahoo_use_api instead")]
 	pub fn yahoo_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
 		self.yahoo_use_api = use_api;
 		self
@@ -148,7 +148,7 @@ impl CheckEmailInput {
 
 	/// Set whether to use Yahoo's API or connecting directly to their SMTP
 	/// servers. Defaults to true.
-	pub fn with_yahoo_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
+	pub fn set_yahoo_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
 		self.yahoo_use_api = use_api;
 		self
 	}

--- a/src/http.rs
+++ b/src/http.rs
@@ -16,7 +16,7 @@
 
 use std::{borrow::Cow, net::SocketAddr};
 
-use check_if_email_exists::{check_email, CheckEmailInput};
+use check_if_email_exists::{check_email, CheckEmailInput, CheckEmailInputProxy};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -63,14 +63,14 @@ async fn req_handler(req: Request<Body>) -> Result<Response<Body>, hyper::Error>
 			// Create EmailInput from body
 			let mut input = CheckEmailInput::new(body.to_emails);
 			input
-				.from_email(body.from_email.unwrap_or_else(|| CONF.from_email.clone()))
-				.hello_name(body.hello_name.unwrap_or_else(|| CONF.hello_name.clone()))
-				.yahoo_use_api(CONF.yahoo_use_api);
+				.with_from_email(body.from_email.unwrap_or_else(|| CONF.from_email.clone()))
+				.with_hello_name(body.hello_name.unwrap_or_else(|| CONF.hello_name.clone()))
+				.with_yahoo_use_api(CONF.yahoo_use_api);
 			if let Some(proxy_host) = body.proxy_host.map(Cow::Owned).or_else(|| CONF.proxy_host.as_ref().map(Cow::Borrowed)) {
-				input.proxy(
-					proxy_host.into_owned(),
-					body.proxy_port.unwrap_or(CONF.proxy_port),
-				);
+				input.with_proxy(CheckEmailInputProxy{
+					host:proxy_host.into_owned(),
+					port: body.proxy_port.unwrap_or(CONF.proxy_port)
+				});
 			}
 
 			let body = check_email(&input).await;

--- a/src/http.rs
+++ b/src/http.rs
@@ -63,11 +63,11 @@ async fn req_handler(req: Request<Body>) -> Result<Response<Body>, hyper::Error>
 			// Create EmailInput from body
 			let mut input = CheckEmailInput::new(body.to_emails);
 			input
-				.with_from_email(body.from_email.unwrap_or_else(|| CONF.from_email.clone()))
-				.with_hello_name(body.hello_name.unwrap_or_else(|| CONF.hello_name.clone()))
-				.with_yahoo_use_api(CONF.yahoo_use_api);
+				.set_from_email(body.from_email.unwrap_or_else(|| CONF.from_email.clone()))
+				.set_hello_name(body.hello_name.unwrap_or_else(|| CONF.hello_name.clone()))
+				.set_yahoo_use_api(CONF.yahoo_use_api);
 			if let Some(proxy_host) = body.proxy_host.map(Cow::Owned).or_else(|| CONF.proxy_host.as_ref().map(Cow::Borrowed)) {
-				input.with_proxy(CheckEmailInputProxy{
+				input.set_proxy(CheckEmailInputProxy{
 					host:proxy_host.into_owned(),
 					port: body.proxy_port.unwrap_or(CONF.proxy_port)
 				});

--- a/src/http.rs
+++ b/src/http.rs
@@ -67,7 +67,7 @@ async fn req_handler(req: Request<Body>) -> Result<Response<Body>, hyper::Error>
 				.set_hello_name(body.hello_name.unwrap_or_else(|| CONF.hello_name.clone()))
 				.set_yahoo_use_api(CONF.yahoo_use_api);
 			if let Some(proxy_host) = body.proxy_host.map(Cow::Owned).or_else(|| CONF.proxy_host.as_ref().map(Cow::Borrowed)) {
-				input.set_proxy(CheckEmailInputProxy{
+				input.set_proxy(CheckEmailInputProxy {
 					host:proxy_host.into_owned(),
 					port: body.proxy_port.unwrap_or(CONF.proxy_port)
 				});

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,11 +77,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	if let Some(to_email) = &CONF.to_email {
 		let mut input = CheckEmailInput::new(vec![to_email.clone()]);
 		input
-			.with_from_email(CONF.from_email.clone())
-			.with_hello_name(CONF.hello_name.clone())
-			.with_yahoo_use_api(CONF.yahoo_use_api);
+			.set_from_email(CONF.from_email.clone())
+			.set_hello_name(CONF.hello_name.clone())
+			.set_yahoo_use_api(CONF.yahoo_use_api);
 		if let Some(proxy_host) = &CONF.proxy_host {
-			input.with_proxy(CheckEmailInputProxy {
+			input.set_proxy(CheckEmailInputProxy {
 				host: proxy_host.clone(),
 				port: CONF.proxy_port,
 			});

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod http;
 
 use std::net::IpAddr;
 
-use check_if_email_exists::{check_email, CheckEmailInput};
+use check_if_email_exists::{check_email, CheckEmailInput, CheckEmailInputProxy};
 use clap::Clap;
 use once_cell::sync::Lazy;
 
@@ -77,11 +77,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	if let Some(to_email) = &CONF.to_email {
 		let mut input = CheckEmailInput::new(vec![to_email.clone()]);
 		input
-			.from_email(CONF.from_email.clone())
-			.hello_name(CONF.hello_name.clone())
-			.yahoo_use_api(CONF.yahoo_use_api);
+			.with_from_email(CONF.from_email.clone())
+			.with_hello_name(CONF.hello_name.clone())
+			.with_yahoo_use_api(CONF.yahoo_use_api);
 		if let Some(proxy_host) = &CONF.proxy_host {
-			input.proxy(proxy_host.clone(), CONF.proxy_port);
+			input.with_proxy(CheckEmailInputProxy {
+				host: proxy_host.clone(),
+				port: CONF.proxy_port,
+			});
 		}
 
 		let result = check_email(&input).await;


### PR DESCRIPTION
It was confusing to have:
- `input.from_email` to get the `from_email` config
- `input.from_email("...")` to set the `from_email` config.

This PR adds `set_` prefix for all setters:
```rust
input.set_from_email("...") // set from_email
```

The old setters are not removed, only deprecated.