### PR TITLE
ci: Only run Travis on release tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ branches:
   only:
     # release tags
     - /^v\d+\.\d+\.\d+.*$/
+    # - master # We used to run Travis on each PR, but now we only have limited Travis credits.
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,6 @@ branches:
   only:
     # release tags
     - /^v\d+\.\d+\.\d+.*$/
-    - master
 
 notifications:
   email:


### PR DESCRIPTION
I got limited free credits for Travis, so only using them for building release binaries, not on PRs.

I'm also looking to switch to Github Actions: #904 