### PR TITLE
use DNS nameservers as configured in host machine

### DIFF
--- a/core/src/mx.rs
+++ b/core/src/mx.rs
@@ -16,7 +16,7 @@
 
 use crate::syntax::SyntaxDetails;
 use crate::util::ser_with_display::ser_with_display;
-use async_std_resolver::{config, lookup::MxLookup, resolver, ResolveError};
+use async_std_resolver::{lookup::MxLookup, resolver_from_system_conf, ResolveError};
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::io::Error;
 
@@ -85,11 +85,7 @@ impl From<ResolveError> for MxError {
 /// Make a MX lookup.
 pub async fn check_mx(syntax: &SyntaxDetails) -> Result<MxDetails, MxError> {
 	// Construct a new Resolver with default configuration options
-	let resolver = resolver(
-		config::ResolverConfig::default(),
-		config::ResolverOpts::default(),
-	)
-	.await?;
+	let resolver = resolver_from_system_conf().await?;
 
 	// Lookup the MX records associated with a name.
 	// The final dot forces this to be an FQDN, otherwise the search rules as specified


### PR DESCRIPTION
Closes: https://github.com/reacherhq/check-if-email-exists/issues/977

This PR changes the DNS resolver so that the host configuration is used. I believe this is the configuration which allows for most customisation since each user can configure nameservers whichever way they want. I think it's also the solution which complies the most with the principle of least astonishment

Before the change, when checking `"someone@gmail.com"`, I was getting:

```
[2021-09-29T14:19:53Z DEBUG trust_dns_proto::xfer::dns_handle] querying: gmail.com MX
[2021-09-29T14:19:53Z DEBUG trust_dns_resolver::name_server::name_server_pool] sending request: [Query { name: Name { is_fqdn: false, label_data: [103, 109, 97, 105, 108, 99, 111, 109], label_ends: [5, 8] }, query_type: MX, query_class: IN }]
[2021-09-29T14:19:53Z DEBUG trust_dns_resolver::name_server::name_server] reconnecting: NameServerConfig { socket_addr: 8.8.8.8:53, protocol: Udp, tls_dns_name: None, trust_nx_responses: true }
```

and after:

```
[2021-09-29T14:18:37Z DEBUG trust_dns_proto::xfer::dns_handle] querying: gmail.com MX
[2021-09-29T14:18:37Z DEBUG trust_dns_resolver::name_server::name_server_pool] sending request: [Query { name: Name { is_fqdn: false, label_data: [103, 109, 97, 105, 108, 99, 111, 109], label_ends: [5, 8] }, query_type: MX, query_class: IN }]
[2021-09-29T14:18:37Z DEBUG trust_dns_resolver::name_server::name_server] reconnecting: NameServerConfig { socket_addr: 192.168.1.241:53, protocol: Udp, tls_dns_name: None, trust_nx_responses: false }
```

Ive also run the tests in the test suite successfully