### PR TITLE
feat: add Outlook HTTP API validation

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -63,6 +63,11 @@ pub struct Cli {
 	#[clap(long, env, default_value = "false", parse(try_from_str))]
 	pub gmail_use_api: bool,
 
+	/// For Outlook/Office 365 email addresses, use Outlook's API instead of
+	/// connecting directly to their SMTP servers.
+	#[clap(long, env, default_value = "false", parse(try_from_str))]
+	pub outlook_use_api: bool,
+
 	/// Whether to check if a gravatar image is existing for the given email.
 	#[clap(long, env, default_value = "false", parse(try_from_str))]
 	pub check_gravatar: bool,
@@ -87,6 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		.set_smtp_port(CONF.smtp_port)
 		.set_yahoo_use_api(CONF.yahoo_use_api)
 		.set_gmail_use_api(CONF.gmail_use_api)
+		.set_outlook_use_api(CONF.outlook_use_api)
 		.set_check_gravatar(CONF.check_gravatar);
 	if let Some(proxy_host) = &CONF.proxy_host {
 		input.set_proxy(CheckEmailInputProxy {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -63,10 +63,10 @@ pub struct Cli {
 	#[clap(long, env, default_value = "false", parse(try_from_str))]
 	pub gmail_use_api: bool,
 
-	/// For Outlook/Office 365 email addresses, use Outlook's API instead of
+	/// For Microsoft 365 email addresses, use OneDrive's API instead of
 	/// connecting directly to their SMTP servers.
 	#[clap(long, env, default_value = "false", parse(try_from_str))]
-	pub outlook_use_api: bool,
+	pub microsoft365_use_api: bool,
 
 	/// Whether to check if a gravatar image is existing for the given email.
 	#[clap(long, env, default_value = "false", parse(try_from_str))]
@@ -92,7 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 		.set_smtp_port(CONF.smtp_port)
 		.set_yahoo_use_api(CONF.yahoo_use_api)
 		.set_gmail_use_api(CONF.gmail_use_api)
-		.set_outlook_use_api(CONF.outlook_use_api)
+		.set_microsoft365_use_api(CONF.microsoft365_use_api)
 		.set_check_gravatar(CONF.check_gravatar);
 	if let Some(proxy_host) = &CONF.proxy_host {
 		input.set_proxy(CheckEmailInputProxy {

--- a/core/src/smtp/hotmail.rs
+++ b/core/src/smtp/hotmail.rs
@@ -168,7 +168,7 @@ fn get_onedrive_url(email_address: &str) -> String {
 	)
 }
 
-/// Use a HTTP request to verify if an Outlook email address exists.
+/// Use a HTTP request to verify if an Microsoft 365 email address exists.
 ///
 /// See
 /// [this article](<https://www.trustedsec.com/blog/achieving-passive-user-enumeration-with-onedrive/>)
@@ -178,17 +178,20 @@ fn get_onedrive_url(email_address: &str) -> String {
 /// a reliable indicator that an email-address is valid. However, a negative
 /// response is ambigious: the email address may or may not be valid but this
 /// cannot be determined by the method outlined here.
-pub async fn check_outlook_api(
+pub async fn check_microsoft365_api(
 	to_email: &EmailAddress,
 	input: &CheckEmailInput,
 ) -> Result<Option<SmtpDetails>, HotmailError> {
 	let url = get_onedrive_url(to_email.as_ref());
 
-	let response = create_client(input, "outlook")?.head(url).send().await?;
+	let response = create_client(input, "microsoft365")?
+		.head(url)
+		.send()
+		.await?;
 
 	log::debug!(
 		target: LOG_TARGET,
-		"[email={}] outlook response: {:?}",
+		"[email={}] microsoft365 response: {:?}",
 		to_email,
 		response
 	);

--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -69,7 +69,7 @@ pub async fn check_smtp(
 			.await
 			.map_err(|err| err.into());
 	}
-	if input.outlook_use_api && host_lowercase.ends_with(".outlook.com.") {
+	if input.outlook_use_api && host_lowercase.ends_with(".mail.protection.outlook.com.") {
 		return hotmail::check_outlook_api(to_email, input)
 			.await
 			.map_err(|err| err.into());

--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -69,6 +69,11 @@ pub async fn check_smtp(
 			.await
 			.map_err(|err| err.into());
 	}
+	if input.outlook_use_api && host_lowercase.ends_with(".outlook.com.") {
+		return hotmail::check_outlook_api(to_email, input)
+			.await
+			.map_err(|err| err.into());
+	}
 	#[cfg(feature = "headless")]
 	if let Some(webdriver) = &input.hotmail_use_headless {
 		// The password recovery page do not always work with Microsoft 365

--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -29,7 +29,7 @@ use async_smtp::EmailAddress;
 use serde::{Deserialize, Serialize};
 use trust_dns_proto::rr::Name;
 
-use crate::util::input_output::CheckEmailInput;
+use crate::{util::input_output::CheckEmailInput, LOG_TARGET};
 use connect::check_smtp_with_retry;
 pub use error::*;
 
@@ -70,9 +70,18 @@ pub async fn check_smtp(
 			.map_err(|err| err.into());
 	}
 	if input.microsoft365_use_api && host_lowercase.ends_with(".mail.protection.outlook.com.") {
-		// Continue in the event of an ambiguous result.
-		if let Some(smtp_details) = hotmail::check_microsoft365_api(to_email, input).await? {
-			return Ok(smtp_details);
+		match hotmail::check_microsoft365_api(to_email, input).await {
+			Ok(Some(smtp_details)) => return Ok(smtp_details),
+			// Continue in the event of an error/ambiguous result.
+			Err(err) => {
+				log::debug!(
+					target: LOG_TARGET,
+					"[email={}] microsoft365 error: {:?}",
+					to_email,
+					err,
+				);
+			}
+			_ => {}
 		}
 	}
 	#[cfg(feature = "headless")]

--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -70,9 +70,10 @@ pub async fn check_smtp(
 			.map_err(|err| err.into());
 	}
 	if input.outlook_use_api && host_lowercase.ends_with(".mail.protection.outlook.com.") {
-		return hotmail::check_outlook_api(to_email, input)
-			.await
-			.map_err(|err| err.into());
+		// Continue in the event of an ambiguous result.
+		if let Some(smtp_details) = hotmail::check_outlook_api(to_email, input).await? {
+			return Ok(smtp_details);
+		}
 	}
 	#[cfg(feature = "headless")]
 	if let Some(webdriver) = &input.hotmail_use_headless {

--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -69,9 +69,9 @@ pub async fn check_smtp(
 			.await
 			.map_err(|err| err.into());
 	}
-	if input.outlook_use_api && host_lowercase.ends_with(".mail.protection.outlook.com.") {
+	if input.microsoft365_use_api && host_lowercase.ends_with(".mail.protection.outlook.com.") {
 		// Continue in the event of an ambiguous result.
-		if let Some(smtp_details) = hotmail::check_outlook_api(to_email, input).await? {
+		if let Some(smtp_details) = hotmail::check_microsoft365_api(to_email, input).await? {
 			return Ok(smtp_details);
 		}
 	}

--- a/core/src/util/input_output.rs
+++ b/core/src/util/input_output.rs
@@ -95,6 +95,11 @@ pub struct CheckEmailInput {
 	///
 	/// Defaults to false.
 	pub gmail_use_api: bool,
+	/// For Outlook/Office 365 email addresses, use Outlook's API instead of
+	/// connecting directly to their SMTP servers.
+	///
+	/// Defaults to false.
+	pub outlook_use_api: bool,
 	// Whether to check if a gravatar image is existing for the given email.
 	//
 	// Defaults to false
@@ -132,6 +137,7 @@ impl Default for CheckEmailInput {
 			smtp_timeout: None,
 			yahoo_use_api: true,
 			gmail_use_api: false,
+			outlook_use_api: false,
 			check_gravatar: false,
 			retries: 2,
 		}
@@ -244,6 +250,13 @@ impl CheckEmailInput {
 	/// servers. Defaults to false.
 	pub fn set_gmail_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
 		self.gmail_use_api = use_api;
+		self
+	}
+
+	/// Set whether to use Outlook's API or connecting directly to their SMTP
+	/// servers. Defaults to false.
+	pub fn set_outlook_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
+		self.outlook_use_api = use_api;
 		self
 	}
 

--- a/core/src/util/input_output.rs
+++ b/core/src/util/input_output.rs
@@ -95,11 +95,11 @@ pub struct CheckEmailInput {
 	///
 	/// Defaults to false.
 	pub gmail_use_api: bool,
-	/// For Outlook/Office 365 email addresses, use Outlook's API instead of
+	/// For Microsoft 365 email addresses, use OneDrive's API instead of
 	/// connecting directly to their SMTP servers.
 	///
 	/// Defaults to false.
-	pub outlook_use_api: bool,
+	pub microsoft365_use_api: bool,
 	// Whether to check if a gravatar image is existing for the given email.
 	//
 	// Defaults to false
@@ -137,7 +137,7 @@ impl Default for CheckEmailInput {
 			smtp_timeout: None,
 			yahoo_use_api: true,
 			gmail_use_api: false,
-			outlook_use_api: false,
+			microsoft365_use_api: false,
 			check_gravatar: false,
 			retries: 2,
 		}
@@ -253,10 +253,10 @@ impl CheckEmailInput {
 		self
 	}
 
-	/// Set whether to use Outlook's API or connecting directly to their SMTP
-	/// servers. Defaults to false.
-	pub fn set_outlook_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
-		self.outlook_use_api = use_api;
+	/// Set whether to use Microsoft 365's OneDrive API or connecting directly
+	/// to their SMTP servers. Defaults to false.
+	pub fn set_microsoft365_use_api(&mut self, use_api: bool) -> &mut CheckEmailInput {
+		self.microsoft365_use_api = use_api;
 		self
 	}
 


### PR DESCRIPTION
- check the validity of Outlook/Office 365 email addresses via the method outlined [here](https://www.trustedsec.com/blog/achieving-passive-user-enumeration-with-onedrive/).
- run only via the `--outlook-use-api` flags (defaulting to `false`.)

relates #937
 