### PR TITLE
fix: split Microsoft 365/Hotmail functionality

### DIFF
--- a/core/src/smtp/error.rs
+++ b/core/src/smtp/error.rs
@@ -16,7 +16,8 @@
 
 use super::gmail::GmailError;
 #[cfg(feature = "headless")]
-use super::hotmail::HotmailError;
+use super::microsoft::hotmail::HotmailError;
+use super::microsoft::microsoft365::Microsoft365Error;
 use super::parser;
 use super::yahoo::YahooError;
 use crate::util::ser_with_display::ser_with_display;
@@ -45,6 +46,7 @@ pub enum SmtpError {
 	/// Error when verifying a Hotmail email via headless browser.
 	#[cfg(feature = "headless")]
 	HotmailError(HotmailError),
+	Microsoft365Error(Microsoft365Error),
 }
 
 impl From<SocksError> for SmtpError {
@@ -75,6 +77,12 @@ impl From<GmailError> for SmtpError {
 impl From<HotmailError> for SmtpError {
 	fn from(e: HotmailError) -> Self {
 		SmtpError::HotmailError(e)
+	}
+}
+
+impl From<Microsoft365Error> for SmtpError {
+	fn from(e: Microsoft365Error) -> Self {
+		SmtpError::Microsoft365Error(e)
 	}
 }
 

--- a/core/src/smtp/error.rs
+++ b/core/src/smtp/error.rs
@@ -46,6 +46,7 @@ pub enum SmtpError {
 	/// Error when verifying a Hotmail email via headless browser.
 	#[cfg(feature = "headless")]
 	HotmailError(HotmailError),
+	/// Error when verifying a Microsoft 365 email via HTTP request.
 	Microsoft365Error(Microsoft365Error),
 }
 

--- a/core/src/smtp/microsoft/microsoft365.rs
+++ b/core/src/smtp/microsoft/microsoft365.rs
@@ -1,0 +1,106 @@
+// check-if-email-exists
+// Copyright (C) 2018-2022 Reacher
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use async_smtp::EmailAddress;
+use reqwest::Error as ReqwestError;
+use serde::Serialize;
+
+use crate::{
+	smtp::{http_api::create_client, SmtpDetails},
+	util::ser_with_display::ser_with_display,
+	CheckEmailInput, LOG_TARGET,
+};
+
+#[derive(Debug, Serialize)]
+pub enum Microsoft365Error {
+	#[serde(serialize_with = "ser_with_display")]
+	ReqwestError(ReqwestError),
+}
+
+impl From<ReqwestError> for Microsoft365Error {
+	fn from(error: ReqwestError) -> Self {
+		Microsoft365Error::ReqwestError(error)
+	}
+}
+
+/// Convert an email address to its corresponding OneDrive URL.
+fn get_onedrive_url(email_address: &str) -> String {
+	let (username, domain) = email_address
+		.split_once('@')
+		.expect("Email address syntax already validated.");
+	let (tenant, _) = domain
+		.split_once('.')
+		.expect("Email domain syntax already validated.");
+
+	format!(
+		"https://{}-my.sharepoint.com/personal/{}_{}/_layouts/15/onedrive.aspx",
+		tenant,
+		username.replace('.', "_"),
+		domain.replace('.', "_"),
+	)
+}
+
+/// Use a HTTP request to verify if an Microsoft 365 email address exists.
+///
+/// See
+/// [this article](<https://www.trustedsec.com/blog/achieving-passive-user-enumeration-with-onedrive/>)
+/// for details on the underlying principles.
+///
+/// Note that a positive response from this function is (at present) considered
+/// a reliable indicator that an email-address is valid. However, a negative
+/// response is ambigious: the email address may or may not be valid but this
+/// cannot be determined by the method outlined here.
+pub async fn check_microsoft365_api(
+	to_email: &EmailAddress,
+	input: &CheckEmailInput,
+) -> Result<Option<SmtpDetails>, Microsoft365Error> {
+	let url = get_onedrive_url(to_email.as_ref());
+
+	let response = create_client(input, "microsoft365")?
+		.head(url)
+		.send()
+		.await?;
+
+	log::debug!(
+		target: LOG_TARGET,
+		"[email={}] microsoft365 response: {:?}",
+		to_email,
+		response
+	);
+
+	if response.status() == 403 {
+		Ok(Some(SmtpDetails {
+			can_connect_smtp: true,
+			is_deliverable: true,
+			..Default::default()
+		}))
+	} else {
+		Ok(None)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_onedrive_url() {
+		let email_address = "lightmand@acmecomputercompany.com";
+		let expected = "https://acmecomputercompany-my.sharepoint.com/personal/lightmand_acmecomputercompany_com/_layouts/15/onedrive.aspx";
+
+		assert_eq!(expected, get_onedrive_url(email_address));
+	}
+}

--- a/core/src/smtp/microsoft/mod.rs
+++ b/core/src/smtp/microsoft/mod.rs
@@ -1,0 +1,3 @@
+#[cfg(feature = "headless")]
+pub mod hotmail;
+pub mod microsoft365;

--- a/core/src/smtp/mod.rs
+++ b/core/src/smtp/mod.rs
@@ -17,9 +17,8 @@
 mod connect;
 mod error;
 mod gmail;
-#[cfg(feature = "headless")]
-mod hotmail;
 mod http_api;
+mod microsoft;
 mod parser;
 mod yahoo;
 
@@ -70,7 +69,7 @@ pub async fn check_smtp(
 			.map_err(|err| err.into());
 	}
 	if input.microsoft365_use_api && host_lowercase.ends_with(".mail.protection.outlook.com.") {
-		match hotmail::check_microsoft365_api(to_email, input).await {
+		match microsoft::microsoft365::check_microsoft365_api(to_email, input).await {
 			Ok(Some(smtp_details)) => return Ok(smtp_details),
 			// Continue in the event of an error/ambiguous result.
 			Err(err) => {
@@ -98,7 +97,7 @@ pub async fn check_smtp(
 		//
 		// So it seems that outlook/hotmail addresses end with `olc.protection.outlook.com.`
 		if host_lowercase.ends_with("olc.protection.outlook.com.") {
-			return hotmail::check_password_recovery(to_email, webdriver)
+			return microsoft::hotmail::check_password_recovery(to_email, webdriver)
 				.await
 				.map_err(|err| err.into());
 		}


### PR DESCRIPTION
`hotmail` was previously behind the `headless` feature which, if disabled, breaks the Microsoft 365 API functionality.

refactor these into a `microsoft` module, leaving the `hotmail` module behind the `headless` feature and allowing the Microsoft 365 API to exist separately.

fixes #1203 

---

I've verified that the Microsoft 365 API behaviour is still working in all previously-tested scenarios. 

Someone more familiar with the Hotmail `headless` feature might want to put that through its paces though…?