### PR TITLE
fix!(core): Bump timeout to 45s, set retries to 1

### DIFF
--- a/backend/src/worker/check_email.rs
+++ b/backend/src/worker/check_email.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use check_if_email_exists::CheckEmailInput;
 use check_if_email_exists::LOG_TARGET;
+use check_if_email_exists::{CheckEmailInput, CheckEmailOutput};
 use lapin::message::Delivery;
 use lapin::{options::*, BasicProperties, Channel};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 use crate::check::check_email;
@@ -26,6 +26,19 @@ use crate::check::check_email;
 #[derive(Debug, Deserialize)]
 pub struct CheckEmailPayload {
 	pub input: CheckEmailInput,
+	pub webhook: Option<CheckEmailWebhook>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CheckEmailWebhook {
+	pub url: String,
+	pub extra: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+struct WebhookOutput {
+	output: CheckEmailOutput,
+	extra: serde_json::Value,
 }
 
 /// Processes the check email task asynchronously.
@@ -65,6 +78,26 @@ pub async fn process_check_email(
 			.await?;
 
 		debug!(target: LOG_TARGET, reply_to=?reply_to, correlation_id=?correlation_id,  "Sent reply")
+	}
+
+	// Check if we have a webhook to send the output to.
+	if let Some(webhook) = payload.webhook {
+		let webhook_output = WebhookOutput {
+			output,
+			extra: webhook.extra,
+		};
+
+		let client = reqwest::Client::new();
+		let res = client
+			.post(webhook.url)
+			.json(&webhook_output)
+			.header("x-reacher-secret", std::env::var("RCH_HEADER_SECRET")?)
+			.send()
+			.await?
+			.text()
+			.await?;
+		debug!(target: LOG_TARGET, email=?webhook_output.output.input,res=?res, "Received webhook response");
+		info!(target: LOG_TARGET, email=?webhook_output.output.input, is_reachable=?webhook_output.output.is_reachable, "Finished check");
 	}
 
 	delivery.ack(BasicAckOptions::default()).await?;

--- a/core/src/rules.json
+++ b/core/src/rules.json
@@ -8,7 +8,11 @@
 		"yahoo.fr": { "rules": ["SkipCatchAll"] }
 	},
 	"by_mx": {
-		"filter30.antispamcloud.com.": { "rules": ["HoneyPot"] }
+		"filter30.antispamcloud.com.": { "rules": ["HoneyPot"] },
+		"futuresinitiative.org.": { "rules": ["SmtpTimeout45s"] },
+		"mail.digimarcon.com.": { "rules": ["SmtpTimeout45s"] },
+		"mail.glasasoftball.org.": { "rules": ["SmtpTimeout45s"] },
+		"nosotrosorg.com.": { "rules": ["SmtpTimeout45s"] }
 	},
 	"by_mx_suffix": {
 		".antispamcloud.com.": {
@@ -19,7 +23,7 @@
 	"rules": {
 		"SkipCatchAll": { "_comment": "Don't perform catch-all check" },
 		"SmtpTimeout45s": {
-			"_comment": "Set SMTP connection timeout to at least 45s. If the user request set an even higher timeout, take that one. Please note that this timeout is **per SMTP connection**. By default, we try 2 connections per email: if the 1st one failed, then we connect again to avoid potential greylisting, in which case the whole verification takes 1min30s."
+			"_comment": "Set SMTP connection timeout to at least 45s. If the user request set an even higher timeout, take that one. Please note that this timeout is **per SMTP connection**. We might try 2 connections per email: if the 1st one failed, then we connect again to avoid potential greylisting, in which case the whole verification takes 1min30s."
 		}
 	}
 }

--- a/core/src/util/input_output.rs
+++ b/core/src/util/input_output.rs
@@ -182,7 +182,7 @@ pub struct CheckEmailInput {
 	/// Add timeout for the SMTP verification step. Set to None if you don't
 	/// want to use a timeout.
 	///
-	/// Defaults to 12s (more than 10s, but when run twice less than 30s).
+	/// Defaults to 30s.
 	pub smtp_timeout: Option<Duration>,
 	/// Select how to verify Yahoo emails.
 	///
@@ -203,9 +203,10 @@ pub struct CheckEmailInput {
 	/// Check if a the email address is present in HaveIBeenPwned API.
 	// If the api_key is filled, HaveIBeenPwned API is checked
 	pub haveibeenpwned_api_key: Option<String>,
-	/// Number of retries of SMTP connections to do.
+	/// Number of retries of SMTP connections to do. Setting to 2 might bypass
+	/// greylisting on some servers, but takes more time.
 	///
-	/// Defaults to 2 to avoid greylisting.
+	/// Defaults to 1.
 	pub retries: usize,
 	/// How to apply TLS to a SMTP client connection.
 	///
@@ -241,7 +242,7 @@ impl Default for CheckEmailInput {
 			proxy: None,
 			smtp_port: 25,
 			smtp_security: SmtpSecurity::default(),
-			smtp_timeout: Some(Duration::from_secs(12)),
+			smtp_timeout: Some(Duration::from_secs(45)),
 			#[cfg(not(feature = "headless"))]
 			yahoo_verif_method: YahooVerifMethod::Api,
 			#[cfg(feature = "headless")]
@@ -253,7 +254,7 @@ impl Default for CheckEmailInput {
 			hotmail_verif_method: HotmailVerifMethod::Headless,
 			check_gravatar: false,
 			haveibeenpwned_api_key: None,
-			retries: 2,
+			retries: 1,
 			skipped_domains: vec![],
 		}
 	}


### PR DESCRIPTION
Vercel functions (used by https://app.reacher.email) usually timeout with a 504 error within less than 60s. So we should absolutely make a verification less than that.

After some testing, Reacher performs better with this setting:
- each SMTP connection times out after 45s, but we don't retry
over this previous setting
- each SMTP connection times out after ~20s, but we do retry once (to avoid greylisting in some rare cases)

Changing the default behaviour in this PR.