### PR TITLE
Fix duplicate `yahoo_verif_method` field in default() inputs

### DIFF
--- a/core/src/util/input_output.rs
+++ b/core/src/util/input_output.rs
@@ -248,8 +248,6 @@ impl Default for CheckEmailInput {
 			#[cfg(feature = "headless")]
 			yahoo_verif_method: YahooVerifMethod::Headless,
 			gmail_verif_method: GmailVerifMethod::Api,
-			#[cfg(not(feature = "headless"))]
-			yahoo_verif_method: HotmailVerifMethod::Smtp,
 			#[cfg(feature = "headless")]
 			hotmail_verif_method: HotmailVerifMethod::Headless,
 			check_gravatar: false,

--- a/core/src/util/input_output.rs
+++ b/core/src/util/input_output.rs
@@ -248,6 +248,8 @@ impl Default for CheckEmailInput {
 			#[cfg(feature = "headless")]
 			yahoo_verif_method: YahooVerifMethod::Headless,
 			gmail_verif_method: GmailVerifMethod::Api,
+			#[cfg(not(feature = "headless"))]
+			hotmail_verif_method: HotmailVerifMethod::OneDriveApi,
 			#[cfg(feature = "headless")]
 			hotmail_verif_method: HotmailVerifMethod::Headless,
 			check_gravatar: false,


### PR DESCRIPTION
I get this bug:

```rust
   Compiling pwned v0.5.0
   Compiling check-if-email-exists v0.9.1 (https://github.com/reacherhq/check-if-email-exists?rev=5ca9097#5ca9097d)
error[E0062]: field `yahoo_verif_method` specified more than once
   --> /Users/khanh/.cargo/git/checkouts/check-if-email-exists-c4445d2e2cd9a1bc/5ca9097/core/src/util/input_output.rs:252:4
    |
247 |             yahoo_verif_method: YahooVerifMethod::Api,
    |             ----------------------------------------- first use of `yahoo_verif_method`
...
252 |             yahoo_verif_method: HotmailVerifMethod::Smtp,
    |             ^^^^^^^^^^^^^^^^^^ used more than once

error[E0277]: the trait bound `DateTime<Utc>: Deserialize<'_>` is not satisfied
```