### PR TITLE
Increase content length limit for bulk validation endpoint

### DIFF
--- a/backend/src/http/v0/bulk/post.rs
+++ b/backend/src/http/v0/bulk/post.rs
@@ -143,7 +143,7 @@ pub fn create_bulk_job(
 		// When accepting a body, we want a JSON body (and to reject huge
 		// payloads)...
 		// TODO: Configure max size limit for a bulk job
-		.and(warp::body::content_length_limit(1024 * 1024 * 50))
+		.and(warp::body::content_length_limit(1024 * 1024 * 50)) // 50 MB limit
 		.and(warp::body::json())
 		.and_then(create_bulk_request)
 		// View access logs by setting `RUST_LOG=reacher_backend`.

--- a/backend/src/http/v0/bulk/post.rs
+++ b/backend/src/http/v0/bulk/post.rs
@@ -143,7 +143,7 @@ pub fn create_bulk_job(
 		// When accepting a body, we want a JSON body (and to reject huge
 		// payloads)...
 		// TODO: Configure max size limit for a bulk job
-		.and(warp::body::content_length_limit(1024 * 16))
+		.and(warp::body::content_length_limit(1024 * 1024 * 50))
 		.and(warp::body::json())
 		.and_then(create_bulk_request)
 		// View access logs by setting `RUST_LOG=reacher_backend`.


### PR DESCRIPTION
Hi! 👋

I noticed the current content length limit of 4KB for the bulk validation endpoint is quite restrictive for real-world usage. I've increased it to 50MB to better accommodate bulk email validation requests.

This change makes the endpoint more practical for validating larger sets of emails in a single request.

Let me know if you'd like me to make any adjustments!