### PR TITLE
fix: Fixed inverted hello-name and from-email in CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,8 +87,8 @@ async fn main() -> Result<(), anyhow::Error> {
 		});
 	let verif_method = VerifMethod::new_with_same_config_for_all(
 		proxy,
-		CONF.from_email.clone(),
 		CONF.hello_name.clone(),
+		CONF.from_email.clone(),
 		CONF.smtp_port,
 		None,
 		1,


### PR DESCRIPTION
The CLI was not working because the call was made with hello-name an from-email inverted. This PR solves this issue.