### PR TITLE
chore: Fix spelling errors in comments

### DIFF
--- a/core/src/misc/mod.rs
+++ b/core/src/misc/mod.rs
@@ -39,7 +39,7 @@ fn load_str_as_hashset(file_content: &str) -> HashSet<String> {
 		.collect()
 }
 
-/// Miscelleanous details about the email address.
+/// Miscellaneous details about the email address.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct MiscDetails {
 	/// Is this a DEA (disposable email account)?
@@ -55,7 +55,7 @@ pub struct MiscDetails {
 	pub haveibeenpwned: Option<bool>,
 }
 
-/// Error occured connecting to this email server via SMTP. Right now this
+/// Error occurred connecting to this email server via SMTP. Right now this
 /// enum has no variant, as `check_misc` cannot fail. But putting a placeholder
 /// right now to avoid future breaking changes.
 #[derive(Debug, Error, Serialize)]

--- a/core/src/smtp/error.rs
+++ b/core/src/smtp/error.rs
@@ -25,7 +25,7 @@ use serde::Serialize;
 use std::time::Duration;
 use thiserror::Error;
 
-/// Error occured connecting to this email server via SMTP.
+/// Error occurred connecting to this email server via SMTP.
 #[derive(Debug, Error, Serialize)]
 #[serde(tag = "type", content = "message")]
 pub enum SmtpError {


### PR DESCRIPTION
## Summary
- fix typos in misc details comment
- fix typo in SMTP error comment

## Testing
- `cargo fmt -- src/misc/mod.rs src/smtp/error.rs` *(fails: 'cargo-fmt' not installed)*
- `cargo test --locked --all --no-run` *(fails: heavy dependency download, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_683f584afb248325b251767e013d5272